### PR TITLE
Establish v1s3r foundation, Module SDK, and Signal Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,199 +1,112 @@
-# VJ ツールプロジェクト ドキュメント
+# v1s3r
 
-## アプリケーションの目的
+v1s3r is a browser-native visual performance system for composing music, media, generated visuals, typography, and human interaction in real time.
 
-このプロジェクトは、ユーザーがリアルタイムでビデオおよびオーディオストリームを対話的に操作できる Web ベースの VJ（ビデオジョッキー）ツールを開発することを目指しています。アプリケーションは、ユーザーの入力とオーディオ解析によって駆動されるさまざまなマルチメディア要素とエフェクトを統合します。
+The project is being rebuilt from the earlier `web-vj` concept. The current development focus is a runtime that treats Remotion expressions as reusable **Visual Modules** with typed input ports. Audio features, pointer gestures, device motion, speech recognition, cues, and future V1P messages can be wired to those ports while the performance is running.
 
-## 仕様
+## Current status
 
-- **サウンドリアクティブ**: オーディオ入力に動的に反応するビジュアル。
-- **3D ビジュアライゼーション**: 視覚的なアウトプットを高めるための 3D グラフィックスの統合。
-- **フィルターとエフェクト**: ビデオストリームを変更するためのグリッチなどの視覚効果を含む。
-- **パーティクルシステム**: 視覚的な複雑さを追加するためのパーティクルアニメーションの実装。
-- **ウェブカメラ統合**: ユーザーのウェブカメラからのライブビデオ入力のキャプチャ。
-- **レイヤリング**: ユーザーがビデオとエフェクトの複数のレイヤーを管理できるようにする。
-- **プラットフォーム**: デスクトップおよびモバイルデバイスを通じてアクセス可能なブラウザベース。
+The repository is in the foundation phase. The previous README described a proposed VJ application structure that did not match the actual repository contents. The project is now defining its runtime contracts and first vertical slice before implementation begins.
 
-## 使用技術
+Tracking Epic: #2
 
-- **Next.js**: フロントエンドフレームワークとして利用し、サーバーサイドレンダリングと静的サイト生成を促進。
-- **React**: コンポーネントベースのアーキテクチャでユーザーインターフェイスを構築。
-- **Three.js**: 3D ビジュアライゼーションの作成と操作。
-- **Web オーディオ API**: リアルタイムのオーディオ処理用。
-- **GitHub Pages**: Next.js によって生成された静的サイトをホスト。
-- **GitHub Actions**: 継続的インテグレーションとデプロイメントのために使用。
+## First vertical slice
 
-## セットアップ
+Three Visual Modules:
 
-1. リポジトリをクローンします。
+- Flow Field
+- Video Layer
+- Kinetic Typography
 
-```bash
-git clone
+Four live bindings:
+
+```text
+audio.bass       -> flow.energy
+pointer.position -> flow.origin
+audio.onset      -> video.jump
+speech.finalText -> typography.text
 ```
 
-2. プロジェクトディレクトリに移動します。
+The composition must be editable, serializable, reloadable, replayable from a Performance Log, and renderable through Remotion.
 
-```bash
-cd vj-tool
+## Architecture
+
+```text
+Audio / Pointer / Motion / Speech / V1P
+                    |
+                    v
+              Signal Runtime
+                    |
+                    v
+              Binding Engine
+                    |
+                    v
+            Module State Store
+                    |
+                    v
+              Remotion Host
+                    |
+                    v
+              Visual Modules
 ```
 
-3. 依存関係をインストールします。
+### Main concepts
 
-```bash
-npm install
-```
+- **Visual Module Definition**: reusable, versioned Remotion/React expression with typed ports
+- **Module Instance**: a placed use of a module definition
+- **Sequence**: time-bounded placement of a module instance
+- **Signal**: normalized continuous value, event, state, text, or asset input
+- **Binding**: `Signal -> Operators -> Module Input`
+- **Composition**: serializable module, sequence, asset, and binding graph
+- **Performance Log**: timestamped input and state record for Replay and Render
 
-4. 開発サーバーを起動します。
+## Execution modes
 
-```bash
-npm run dev
-```
+- **Live**: realtime browser input and performance clock
+- **Preview**: Remotion Player clock and simulated/editor input
+- **Replay**: recorded Performance Log
+- **Render**: Remotion frame clock with deterministic inputs
 
-5. ブラウザでアプリケーションにアクセスします。
+## Documentation
 
-```bash
-http://localhost:3000
-```
+- [Project charter](docs/charter.md)
+- [Architecture overview](docs/architecture/overview.md)
+- [MVP vertical slice](docs/product/mvp.md)
+- [Architecture decision backlog](docs/decisions/README.md)
 
-## ディレクトリ構造
+## Responsibility boundaries
 
-```bash
-vj-tool
-├── .github
-│   └── workflows
-│       └── deploy.yml
-├── components
-│   ├── AudioVisualizer.js
-│   ├── Controls.js
-│   ├── Layer.js
-│   ├── ParticleSystem.js
-│   ├── VideoLayer.js
-│   └── WebcamCapture.js
-├── pages
-│   ├── _app.js
-│   ├── _document.js
-│   ├── index.js
-│   └── styles.css
-├── public
-│   ├── favicon.ico
-│   └── manifest.json
-├── styles
-│   └── globals.css
-├── .gitignore
-├── next.config.js
-├── package.json
-└── README.md
-```
+### v1s3r
 
-## コンポーネント
+Visual Module SDK, Signal Runtime, Binding Engine, Remotion Host integration, editor, performance logging, replay, and live rendering.
 
-### AudioVisualizer
+### Remotion
 
-オーディオ入力に基づいてビジュアルエフェクトを生成するコンポーネント。
+Sequence composition, preview playback, frame-based replay, and offline rendering.
 
-### Controls
+### SENN
 
-アプリケーションのコントロールパネルを提供するコンポーネント。
+Future peer sessions, connection, transport, reconnection, and capability exchange.
 
-### Layer
+### V1P
 
-ビデオレイヤーを管理するコンポーネント。
+Future peer messages for visual intent, state, cues, time, health, and snapshots. V1P messages will enter v1s3r through the common Signal model.
 
-### ParticleSystem
+## Development order
 
-パーティクルアニメーションを生成するコンポーネント。
+1. Project charter and architecture boundaries — #3
+2. Visual Module SDK and registry — #4
+3. Signal Runtime and input adapters — #5
+4. Binding Engine — #6
+5. Remotion Host — #7
+6. Editor and Wiring Table — #8
+7. Device-tested vertical slice — #9
 
-### VideoLayer
+## Non-goals for the first stage
 
-ビデオストリームを表示するコンポーネント。
-
-### WebcamCapture
-
-ウェブカメラからのビデオ入力をキャプチャするコンポーネント。
-
-## ページ
-
-### index
-
-アプリケーションのメインページ。
-
-## スタイル
-
-### globals
-
-アプリケーション全体のスタイルを定義する CSS ファイル。
-
-## カスタムドキュメント
-
-### \_document
-
-アプリケーションの HTML ドキュメントのカスタム設定を提供するファイル。
-
-## カスタムアプリケーション
-
-### \_app
-
-アプリケーションのルートコンポーネントをカスタマイズするファイル。
-
-## 拡張機能
-
-### Next.js
-
-Next.js は、React アプリケーションの開発を簡素化し、サーバーサイドレンダリングと静的サイト生成をサポートします。これにより、パフォーマンスの向上と SEO の最適化が可能になります。
-
-### Three.js
-
-Three.js は、WebGL を使用して 3D グラフィックスを描画するための JavaScript ライブラリです。これにより、アプリケーションにリッチなビジュアライゼーションを統合できます。
-
-### Web オーディオ API
-
-Web オーディオ API は、ブラウザでリアルタイムのオーディオ処理を実行するための API です。これにより、オーディオ入力に基づいてビジュアルエフェクトを生成できます。
-
-## GitHub Pages
-
-GitHub Pages は、GitHub リポジトリから静的サイトをホストするための無料のサービスです。これにより、アプリケーションを簡単に公開し、共有できます。
-
-## GitHub Actions
-
-GitHub Actions は、GitHub リポジトリ内で継続的インテグレーションとデプロイメントを自動化するためのツールです。これにより、品質の高いコードを保証し、効率的な開発プロセスを実現できます。
-
-## GitHub Actions を使用した GitHub Pages へのデプロイメントワークフロー
-
-### 概要
-
-このワークフローは、Next.js プロジェクトのビルド、テストの実行、および成功したビルドを GitHub Pages にデプロイするプロセスを自動化します。これにより、品質の高いコードのみが本番環境にデプロイされることを保証します。
-
-### トリガーイベント
-
-- **Push**: `main` ブランチへのプッシュがトリガー。
-- **Workflow Dispatch**: GitHub Actions タブから手動でワークフローを実行可能。
-
-### パーミッション
-
-- **Contents**: 読み取り専用アクセス。
-- **Pages**: GitHub Pages へのデプロイのための書き込み権限。
-- **ID-Token**: ID トークン生成のための書き込み権限。
-
-### 並行処理の管理
-
-同時に一つのデプロイメントのみを実行し、進行中のデプロイメントはキャンセルせずに、最新のキューのみを実行します。
-
-### ジョブ
-
-#### ビルドジョブ
-
-- コードのチェックアウト
-- パッケージマネージャの検出（npm または yarn）
-- Node.js 環境のセットアップ
-- 依存関係のインストール
-- Next.js アプリケーションのビルド
-- 単体および統合テストの実行
-- ビルドアーティファクトのアップロード
-
-#### デプロイジョブ
-
-ビルドジョブが成功した場合のみ実行されるデプロイメントステップです。GitHub Pages へのデプロイを行います。
-
-## 結論
-
-このドキュメントは VJ ツールプロジェクトの包括的なガイドとして機能し、アプリケーションの目的、仕様、自動デプロイメントプロセスの詳細を説明しています。開発者やユーザーが効果的にツールを理解し、利用するための支援を目的としています。
+- Full replacement for Resolume or TouchDesigner
+- Arbitrary unsigned JavaScript from external URLs
+- General-purpose node programming
+- Frame-perfect multi-device pixel synchronization
+- Large-scale distributed consensus
+- Full MIDI, OSC, DMX, NDI, or broadcast integration

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,144 @@
+# v1s3r Architecture Overview
+
+## System shape
+
+```text
+Input adapters
+  Audio / Pointer / Motion / Speech / V1P
+              |
+              v
+        Signal Runtime
+              |
+              v
+        Binding Engine
+              |
+              v
+       Module State Store
+              |
+              v
+        Remotion Host
+              |
+              v
+       Visual Modules
+              |
+              v
+      Browser visual output
+```
+
+The persistent unit is a `Composition`. A composition references module instances, sequences, bindings, assets, timing settings, and variables. Runtime-only browser handles, streams, object URLs, and Web Audio nodes are never persisted.
+
+## Canonical vocabulary
+
+### Visual Module Definition
+
+A versioned, reusable implementation of a visual expression. It declares:
+
+- stable module ID and semantic version
+- React/Remotion component
+- typed input ports
+- output events
+- default values
+- runtime capabilities
+
+### Module Instance
+
+A placed use of one Visual Module Definition. Multiple instances may reference the same definition. Bindings target an `instanceId` and `inputId`, never only a module ID.
+
+### Sequence
+
+A time-bounded placement of a module instance or nested composition. It defines start, duration, trim, layer, and timing behavior.
+
+### Signal
+
+A normalized runtime input carrying value, timestamp, sequence number, and source. Signals are classified as continuous, event, state, text, or asset.
+
+### Binding
+
+A declarative connection:
+
+```text
+Signal source -> ordered operators -> Module Instance input
+```
+
+A binding also declares update mode and conflict policy.
+
+### Composition
+
+The serializable graph containing module instances, sequences, bindings, assets, variables, and format settings.
+
+### Performance Set
+
+A distributable package containing a composition, approved module references, assets, fonts, presets, metadata, and optional rehearsal data.
+
+### Performance Log
+
+A time-ordered record of signals, cues, state changes, and relevant runtime events used for replay and deterministic rendering.
+
+## Package boundaries
+
+```text
+packages/
+  module-sdk/
+  signal-runtime/
+  binding-engine/
+  remotion-host/
+  v1p-adapter/
+  schema/
+
+apps/
+  editor/
+  performer/
+  render-worker/      # optional after the browser MVP
+
+modules/
+  flow-field/
+  video-layer/
+  kinetic-typography/
+```
+
+The initial repository may remain a single application while these boundaries are represented as internal directories. Package extraction should happen only when contracts are stable.
+
+## Two update paths
+
+### State input path
+
+For low-frequency or semantic values:
+
+- text
+- color
+- media selection
+- visibility
+- scene or preset
+- layout
+- role and ownership
+
+These values are batched into Module State Store and supplied as resolved props.
+
+### Realtime input path
+
+For high-frequency values:
+
+- audio level and frequency bands
+- pointer coordinates
+- device orientation
+- shader uniforms
+- particle force and density
+
+These values live in mutable typed buffers or an external store. A module reads the latest value from its animation or GPU render loop. They must not force a full React render every animation frame.
+
+## Execution modes
+
+| Mode | Time source | Input source | Failure policy |
+|---|---|---|---|
+| Live | session/performance clock | realtime adapters | continue with fallback |
+| Preview | Remotion Player clock | editor and simulated signals | expose diagnostics |
+| Replay | recorded timestamps | Performance Log | preserve event order |
+| Render | Remotion frame clock | log, seed, assets | wait for required assets or fail explicitly |
+
+## Module isolation
+
+Each module runs behind an error boundary. A failed module is replaced with a transparent or diagnostic fallback without stopping sibling modules. Runtime adapters follow the same isolation rule: unavailable speech recognition must not disable audio, pointer, or rendering.
+
+## Future SENN/V1P integration
+
+SENN is transport infrastructure and does not know module internals. V1P messages are converted by a V1P adapter into ordinary Signals and state updates. This keeps local and remote interaction on the same Binding Engine path.

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -1,0 +1,114 @@
+# v1s3r Project Charter
+
+## Purpose
+
+v1s3r is a browser-native visual performance system for composing music, media assets, generated visuals, typography, and human interaction in real time.
+
+It treats Remotion compositions as reusable visual modules rather than finished videos. Modules expose typed input ports and output events, and the runtime connects audio features, touch, motion, speech recognition, cues, and future V1P messages to those ports.
+
+## Core proposition
+
+A performer can load visual modules, place them on a sequence, wire live signals to their parameters, perform in real time, save the composition, replay recorded interaction, and render the same performance offline.
+
+## Principles
+
+1. Music alone must produce a coherent visual result.
+2. Human interaction modifies the musical visual system without destroying timing coherence.
+3. Visual modules are reusable objects with explicit contracts.
+4. High-frequency signals are not pushed through React state every frame.
+5. Live, Preview, Replay, and Render use the same module definitions.
+6. Pixel streams are not the default synchronization unit; visual intent, state, events, and time are.
+7. Failure of one module or input adapter must not stop the entire performance.
+8. Preparation, editing, performance, and diagnosis are separate modes.
+
+## Product boundaries
+
+### v1s3r owns
+
+- Visual Module SDK and registry
+- module instances and compositions
+- signal normalization
+- interaction bindings and operators
+- Remotion host integration
+- sequence and performance-set editing
+- performance logging and replay
+- live visual rendering and graceful fallback
+
+### Remotion owns
+
+- sequence and frame-based composition
+- preview playback
+- deterministic replay support
+- offline rendering
+
+### Remotion does not own
+
+- microphone capture
+- audio feature extraction
+- pointer and device-motion capture
+- browser speech recognition
+- WebRTC or peer management
+- failover and ownership transfer
+
+### SENN owns
+
+- session participation
+- peer discovery and connection
+- data-channel transport
+- reconnection and peer capability exchange
+
+### V1P owns
+
+- visual intent, state, cue, timing, health, and snapshot messages exchanged between peers
+
+## Initial users
+
+- A solo performer using one browser and one display
+- A performer using an iPhone as controller and renderer
+- Two performers sharing different control roles
+- A visual-module developer creating reusable Remotion-based expressions
+
+## MVP
+
+The first vertical slice uses three modules:
+
+- Flow Field
+- Video Layer
+- Kinetic Typography
+
+And four bindings:
+
+- `audio.bass -> flow.energy`
+- `pointer.position -> flow.origin`
+- `audio.onset -> video.jump`
+- `speech.finalText -> typography.text`
+
+The composition must be editable, serializable, reloadable, replayable from a performance log, and renderable through Remotion.
+
+## Success criteria
+
+- Three modules run together on iPhone Safari.
+- Wiring changes are reflected immediately in the preview.
+- Continuous signals do not trigger full React-tree updates at frame rate.
+- A saved composition restores the same modules, sequence, and bindings.
+- Recorded signals reproduce the event order and principal visual changes.
+- Module failure, missing media, or unavailable speech recognition degrades safely.
+
+## Non-goals for the first stage
+
+- Full replacement for Resolume, TouchDesigner, or After Effects
+- Arbitrary unsigned JavaScript loaded from external URLs
+- A general-purpose visual programming language
+- Frame-perfect multi-device pixel synchronization
+- Large-scale distributed consensus
+- Fully autonomous AI VJ performance
+- Comprehensive MIDI, OSC, DMX, NDI, and broadcast support
+
+## Decision rule
+
+A feature belongs in the MVP only when it proves at least one of the following:
+
+- a Remotion expression can operate as a reusable module;
+- a live signal can safely change a module in real time;
+- the same composition can move between Live, Preview, Replay, and Render;
+- the performance continues under a realistic browser or module failure.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,39 @@
+# Architecture Decision Records
+
+This directory records decisions that constrain module authors, runtime implementations, saved compositions, and future distributed execution.
+
+## Proposed ADRs
+
+| ADR | Decision | Status |
+|---|---|---|
+| ADR-001 | Treat Remotion expressions as contract-based Visual Modules | Proposed |
+| ADR-002 | Separate low-frequency state inputs from high-frequency realtime signals | Proposed |
+| ADR-003 | Use an approved registry before supporting external module packages | Proposed |
+| ADR-004 | Persist compositions as versioned data, never browser runtime objects | Proposed |
+| ADR-005 | Use one module contract across Live, Preview, Replay, and Render | Proposed |
+| ADR-006 | Adapt V1P into the common Signal model instead of adding remote-only bindings | Proposed |
+| ADR-007 | Use session time for live events and Remotion frame time for offline rendering | Proposed |
+| ADR-008 | Isolate module and adapter failures rather than failing the composition | Proposed |
+
+## ADR template
+
+```markdown
+# ADR-NNN: Title
+
+- Status: Proposed | Accepted | Superseded | Rejected
+- Date: YYYY-MM-DD
+
+## Context
+
+## Decision
+
+## Consequences
+
+### Positive
+
+### Negative
+
+## Alternatives considered
+
+## Validation
+```

--- a/docs/product/mvp.md
+++ b/docs/product/mvp.md
@@ -1,0 +1,121 @@
+# MVP: Remotion Visual Module Vertical Slice
+
+## Hypothesis
+
+A Remotion-based visual expression can be loaded as a reusable module, placed in a sequence, changed by live interaction, saved as data, replayed from recorded signals, and rendered offline without maintaining separate implementations for each mode.
+
+## Demonstration flow
+
+1. Open the editor and load the default Performance Set.
+2. Add Flow Field, Video Layer, and Kinetic Typography module instances.
+3. Place each instance on the sequence and set layer order.
+4. Create four bindings in the Wiring Table.
+5. Start microphone input and confirm bass/onset signals.
+6. Move or tap the pointer and confirm position input.
+7. Speak and confirm final recognized text.
+8. Modify an operator while running and observe the result immediately.
+9. Save the composition as JSON.
+10. Reload the page and restore it.
+11. Record a short Performance Log.
+12. Replay the log.
+13. Render the replay through Remotion.
+
+## Required modules
+
+### Flow Field
+
+Inputs:
+
+- `energy: number (0..1, realtime)`
+- `origin: vector2 (0..1, realtime)`
+- `density: number (state)`
+- `palette: enum/color set (state)`
+
+### Video Layer
+
+Inputs:
+
+- `asset: asset reference`
+- `jump: trigger`
+- `opacity: number`
+- `playbackRate: number`
+
+### Kinetic Typography
+
+Inputs:
+
+- `text: string`
+- `intensity: number`
+- `explode: trigger`
+- `direction: vector2`
+
+## Required signals
+
+- `audio.bass`
+- `audio.onset`
+- `pointer.position`
+- `speech.finalText`
+
+## Required bindings
+
+```text
+audio.bass       -> smooth -> mapRange -> flow.energy
+pointer.position -> flow.origin
+audio.onset      -> debounce -> video.jump
+speech.finalText -> typography.text
+```
+
+## Composition persistence
+
+The saved document must contain:
+
+- schema version
+- format and timing
+- module definition references and versions
+- module instances and initial inputs
+- sequence placements
+- bindings and operator order
+- asset references
+- variables and presets
+
+It must not contain:
+
+- MediaStream objects
+- AudioContext nodes
+- Blob URLs
+- DOM nodes
+- WebRTC peer handles
+- browser permission state
+
+## Acceptance criteria
+
+### Functionality
+
+- All three modules are instantiated through the same SDK contract.
+- The four bindings can be created without editing source code.
+- Bindings can be enabled, disabled, and modified during Preview or Live mode.
+- Save and reload restore the same module graph and bindings.
+- Replay preserves event order and major visual transitions.
+- Offline rendering accepts the same composition and performance log.
+
+### Performance
+
+- Target 60 fps on iPhone 16 Pro Max; graceful reduction to at least 30 fps where necessary.
+- High-frequency signals do not update the entire React component tree per frame.
+- Ten-minute operation shows no unbounded event queue or obvious memory leak.
+
+### Resilience
+
+- Speech recognition failure does not interrupt other visuals.
+- A missing video asset produces a fallback layer.
+- A module exception is isolated by an error boundary.
+- Invalid bindings are disabled with an actionable diagnostic.
+
+## Exit decision
+
+After this slice, proceed to SENN/V1P integration only when:
+
+- module and binding contracts are stable enough to serialize;
+- iPhone Safari performance is measurable and acceptable;
+- Replay and Render use the same composition semantics;
+- remote signals can be represented without introducing a second interaction model.

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },
-  "peerDependencies": {
-    "react": "^19.2.7",
-    "remotion": "^4.0.499"
-  },
   "engines": {
     "node": ">=22"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "v1s3r",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "typecheck": "tsc -b",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "react": "^19.2.7",
+    "remotion": "^4.0.499"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/module-sdk/package.json
+++ b/packages/module-sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@v1s3r/module-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  },
+  "peerDependencies": {
+    "react": "^19.2.7"
+  }
+}

--- a/packages/module-sdk/src/index.ts
+++ b/packages/module-sdk/src/index.ts
@@ -1,0 +1,70 @@
+import type {ComponentType} from 'react';
+
+export type ModuleInput =
+  | {id: string; type: 'number'; default: number; min?: number; max?: number; realtime?: boolean}
+  | {id: string; type: 'boolean'; default: boolean}
+  | {id: string; type: 'string'; default: string}
+  | {id: string; type: 'color'; default: string}
+  | {id: string; type: 'vector2'; default: readonly [number, number]; realtime?: boolean}
+  | {id: string; type: 'enum'; default: string; options: readonly string[]}
+  | {id: string; type: 'trigger'}
+  | {id: string; type: 'asset'; accepts: readonly ('image' | 'video' | 'audio' | 'svg')[]};
+
+export interface ModuleRuntime {
+  readonly mode: 'live' | 'preview' | 'replay' | 'render';
+  readonly frame: number;
+  readonly fps: number;
+  readonly timeSeconds: number;
+  getNumber(signalId: string): number;
+  getVector2(signalId: string): readonly [number, number];
+}
+
+export interface VisualModuleProps<TInputs extends Record<string, unknown>> {
+  readonly inputs: Readonly<TInputs>;
+  readonly runtime: ModuleRuntime;
+  emit(eventName: string, payload?: unknown): void;
+}
+
+export interface VisualModuleDefinition<TInputs extends Record<string, unknown>> {
+  readonly id: string;
+  readonly version: `${number}.${number}.${number}`;
+  readonly title: string;
+  readonly component: ComponentType<VisualModuleProps<TInputs>>;
+  readonly inputs: readonly ModuleInput[];
+  readonly defaultInputs: Readonly<TInputs>;
+  readonly capabilities: {
+    readonly live: boolean;
+    readonly deterministic: boolean;
+    readonly offlineRender: boolean;
+    readonly transparent: boolean;
+  };
+}
+
+export interface ModuleInstance {
+  readonly instanceId: string;
+  readonly moduleId: string;
+  readonly moduleVersion: string;
+  readonly layer: number;
+  readonly initialInputs: Readonly<Record<string, unknown>>;
+}
+
+export const defineVisualModule = <TInputs extends Record<string, unknown>>(
+  definition: VisualModuleDefinition<TInputs>,
+): VisualModuleDefinition<TInputs> => definition;
+
+export class ModuleRegistry {
+  readonly #definitions = new Map<string, VisualModuleDefinition<Record<string, unknown>>>();
+
+  register<TInputs extends Record<string, unknown>>(definition: VisualModuleDefinition<TInputs>): void {
+    const key = `${definition.id}@${definition.version}`;
+    if (this.#definitions.has(key)) throw new Error(`Visual Module already registered: ${key}`);
+    this.#definitions.set(key, definition as VisualModuleDefinition<Record<string, unknown>>);
+  }
+
+  resolve(moduleId: string, version: string): VisualModuleDefinition<Record<string, unknown>> {
+    const key = `${moduleId}@${version}`;
+    const definition = this.#definitions.get(key);
+    if (!definition) throw new Error(`Visual Module not found: ${key}`);
+    return definition;
+  }
+}

--- a/packages/module-sdk/tsconfig.json
+++ b/packages/module-sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/signal-runtime/package.json
+++ b/packages/signal-runtime/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@v1s3r/signal-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/signal-runtime/src/index.ts
+++ b/packages/signal-runtime/src/index.ts
@@ -1,0 +1,76 @@
+export type SignalKind = 'continuous' | 'event' | 'state' | 'text' | 'asset';
+
+export interface Signal<T = unknown> {
+  readonly id: string;
+  readonly kind: SignalKind;
+  readonly value: T;
+  readonly timestamp: number;
+  readonly sequence: number;
+  readonly source: string;
+}
+
+export interface PerformanceLogEntry<T = unknown> extends Signal<T> {}
+
+export class RealtimeBuffer {
+  readonly #numbers = new Map<string, number>();
+  readonly #vectors = new Map<string, readonly [number, number]>();
+
+  setNumber(id: string, value: number): void {
+    if (!Number.isFinite(value)) throw new TypeError(`Signal ${id} must be finite`);
+    this.#numbers.set(id, value);
+  }
+
+  getNumber(id: string, fallback = 0): number {
+    return this.#numbers.get(id) ?? fallback;
+  }
+
+  setVector2(id: string, value: readonly [number, number]): void {
+    if (!value.every(Number.isFinite)) throw new TypeError(`Signal ${id} must be a finite vector`);
+    this.#vectors.set(id, value);
+  }
+
+  getVector2(id: string, fallback: readonly [number, number] = [0, 0]): readonly [number, number] {
+    return this.#vectors.get(id) ?? fallback;
+  }
+}
+
+export class SignalStore {
+  readonly realtime = new RealtimeBuffer();
+  readonly #latest = new Map<string, Signal>();
+  readonly #events: Signal[] = [];
+  readonly #subscribers = new Set<(signal: Signal) => void>();
+
+  publish<T>(signal: Signal<T>): void {
+    const previous = this.#latest.get(signal.id);
+    if (previous && signal.sequence <= previous.sequence) return;
+
+    this.#latest.set(signal.id, signal as Signal);
+    if (signal.kind === 'event') this.#events.push(signal as Signal);
+    for (const subscriber of this.#subscribers) subscriber(signal as Signal);
+  }
+
+  latest<T = unknown>(id: string): Signal<T> | undefined {
+    return this.#latest.get(id) as Signal<T> | undefined;
+  }
+
+  drainEvents(): Signal[] {
+    return this.#events.splice(0, this.#events.length);
+  }
+
+  subscribe(subscriber: (signal: Signal) => void): () => void {
+    this.#subscribers.add(subscriber);
+    return () => this.#subscribers.delete(subscriber);
+  }
+}
+
+export class PerformanceLog {
+  readonly #entries: PerformanceLogEntry[] = [];
+
+  append(entry: PerformanceLogEntry): void {
+    this.#entries.push(entry);
+  }
+
+  snapshot(): readonly PerformanceLogEntry[] {
+    return [...this.#entries].sort((a, b) => a.timestamp - b.timestamp || a.sequence - b.sequence);
+  }
+}

--- a/packages/signal-runtime/tsconfig.json
+++ b/packages/signal-runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./packages/module-sdk"},
+    {"path": "./packages/signal-runtime"}
+  ]
+}


### PR DESCRIPTION
Closes #3
Starts #4
Starts #5

## What changed

### Product and architecture foundation
- Repositioned the repository from the stale generic `web-vj` proposal to the current v1s3r direction.
- Added the project charter, canonical terminology, runtime boundaries, execution modes, MVP, and ADR backlog.

### TypeScript workspace
- Added an npm workspace and TypeScript project references.
- Added shared strict compiler settings.
- Added package boundaries for `@v1s3r/module-sdk` and `@v1s3r/signal-runtime`.

### Initial Module SDK
- Added Visual Module Definition, Module Instance, typed input ports, runtime context, capabilities, `defineVisualModule()`, and a versioned Module Registry.

### Initial Signal Runtime
- Added the common Signal envelope and signal kinds.
- Added a high-frequency numeric/vector Realtime Buffer.
- Added latest-value storage, event queueing, subscriptions, sequence-based stale-event rejection, and an ordered Performance Log.

## Why

The repository previously had documentation for an application structure that did not exist and had no package manifest. This PR creates both the stable vocabulary and the first compilable implementation contracts needed for the Remotion module runtime.

## Developer impact

After this PR is accepted:
- #4 can continue with schema validation, module lifecycle, fallback modules, tests, and example modules.
- #5 can continue with Audio, Pointer, Motion, Speech, and V1P adapters plus log replay.
- #6 can implement Binding Engine contracts against stable Module and Signal types.

## Validation status

- Documentation and contracts were reviewed for naming and boundary consistency.
- A TypeScript workspace and typecheck command are present.
- Dependency installation and executable typecheck have not yet been run through the connector environment; this remains a required validation before marking the PR ready.

## Current dependency versions

The workspace currently pins TypeScript 7.0.2 and Vitest 4.1.10 based on the package registry versions checked on July 26, 2026. Remotion is intentionally not installed until the Host package is introduced.

## Follow-up

- #4 Module SDK validation, lifecycle, tests, and example modules
- #5 Signal adapters and replay
- #6 Binding Engine
- #7 Remotion Host
- #8 Editor
- #9 Vertical slice device validation