### PR TITLE
chore: establish Opus 5 autonomous VJ development loop

### DIFF
--- a/.claude/state/loop-state.md
+++ b/.claude/state/loop-state.md
@@ -1,0 +1,41 @@
+# Autonomous loop state
+
+Status: IDLE
+
+## Current performance slice
+
+-
+
+## Input sources
+
+-
+
+## Target modules / sequences
+
+-
+
+## In scope
+
+-
+
+## Out of scope
+
+-
+
+## Acceptance criteria
+
+- [ ] The sequence/module loads through a documented contract
+- [ ] Public parameters can be wired to at least one real-time source
+- [ ] Audio/visual timing behavior is verified
+- [ ] Browser permission and unavailable-device fallbacks work
+- [ ] Frame time, console errors and resource cleanup are checked
+- [ ] Build/tests pass without weakening existing checks
+- [ ] Visual evidence is recorded
+
+## Verification evidence
+
+-
+
+## Remaining risks
+
+-

--- a/.claude/state/loop-state.md
+++ b/.claude/state/loop-state.md
@@ -6,13 +6,54 @@ Status: IDLE
 
 -
 
+## Actor and performance outcome
+
+- Actor:
+- Outcome:
+
+## Related experience journey
+
+- Journey ID:
+- Step:
+- Source: `docs/experience/README.md`
+
+## Performance state timeline
+
+- Entry state:
+- Expected transitions:
+- Exit state:
+- Degraded/fallback states:
+
 ## Input sources
 
 -
 
-## Target modules / sequences
+## Target modules / sequences / parameters
 
 -
+
+## Interaction and timing contract
+
+- Input event:
+- Mapping / transform:
+- Expected visual response:
+- Timing / synchronization expectation:
+- Transition behavior:
+
+## Performance budget and fallback
+
+- Frame / long-task budget:
+- Audio/visual drift budget:
+- Input latency budget:
+- Permission/device fallback:
+- Low-performance fallback:
+
+## Resource lifecycle
+
+- Resources created:
+- Owner:
+- Cleanup trigger:
+- Leak/double-registration prevention:
 
 ## In scope
 
@@ -22,17 +63,38 @@ Status: IDLE
 
 -
 
-## Acceptance criteria
+## Experience acceptance criteria
+
+- [ ] The performer can understand the active scene, source and target parameter
+- [ ] Authoring, armed, live and degraded states cannot be confused
+- [ ] The live flow remains controllable and recoverable
+- [ ] Permission, device and performance failures have a usable fallback
+- [ ] The intended musical/visual response is observable, not only technically triggered
+
+## Technical acceptance criteria
 
 - [ ] The sequence/module loads through a documented contract
 - [ ] Public parameters can be wired to at least one real-time source
-- [ ] Audio/visual timing behavior is verified
+- [ ] Audio/visual timing behavior is measured
 - [ ] Browser permission and unavailable-device fallbacks work
 - [ ] Frame time, console errors and resource cleanup are checked
 - [ ] Build/tests pass without weakening existing checks
-- [ ] Visual evidence is recorded
+
+## Evaluation level
+
+- [ ] static/contract
+- [ ] deterministic tests
+- [ ] instrumentation
+- [ ] DOM/control review
+- [ ] screenshot for changed UI only
+- [ ] short capture/replay
+- [ ] human rehearsal
 
 ## Verification evidence
+
+-
+
+## Rehearsal / outcome evidence
 
 -
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — web-vj
 
-ブラウザ上で映像、音声、タイポグラフィ、3D、映像素材、インタラクションをリアルタイムに組み合わせるVJ実行・制作基盤。
+ブラウザ上で映像、音声、タイポグラフィ、3D、映像素材、インタラクションをリアルタイムに組み合わせるVJ実行・制作基盤。ユーザー向け変更では `docs/experience/README.md` を体験設計の正本として併用する。
 
 ## Current direction
 
@@ -13,12 +13,32 @@
 ## Autonomous development loop
 
 1. 編集前に現行実装、README、関連Issue、既存のvisual/audio処理を調査する。
-2. 変更範囲、非変更範囲、受入条件、性能予算、検証方法を明示する。
-3. 一度に一つの演奏可能・デモ可能なvertical sliceを完成させる。
-4. Opus 5はarchitecture、module contract、interaction graph、難しい同期/性能障害へ使う。
-5. 通常実装はSonnet、探索は読み取り専用の安価なagentへ委任する。
-6. サブエージェントは独立した大規模作業だけに使い、同じscene/moduleを並行編集させない。
-7. 同じ失敗が3回続いたらパッチを止め、timing、frame、audio clock、render loop、browser API、GPU/CPUを分けて根本原因分析する。
+2. `docs/experience/README.md` から Actor、Journey ID/step、entry/exit/degraded state を特定する。
+3. 変更範囲、非変更範囲、体験・技術の受入条件、性能予算、fallback、検証方法を明示する。
+4. `.claude/state/loop-state.md` に module/sequence/source/parameter、timing contract、resource lifecycle、評価レベルを記録する。
+5. 一度に一つの演奏可能・デモ可能なvertical sliceを完成させる。
+6. Opus 5はarchitecture、module contract、interaction graph、journey/state整合、難しい同期/性能障害へ使う。
+7. 通常実装はSonnet、探索は読み取り専用の安価なagentへ委任する。
+8. サブエージェントは独立した大規模作業だけに使い、同じscene/moduleを並行編集させない。
+9. 同じ失敗が3回続いたらパッチを止め、timing、frame、audio clock、render loop、browser API、GPU/CPUを分けて根本原因分析する。
+
+## Experience loop
+
+`Performance journey -> State/timing contract -> Module and mapping contract -> Playable vertical slice -> Instrumented evaluation -> Rehearsal outcome`
+
+ユーザー向け変更は最低限以下を定義する。
+
+- Actor / performance outcome
+- Related journey ID and step
+- Entry, exit and degraded states
+- Target module/sequence/source/parameter
+- Interaction and timing contract
+- Performance budget and fallback
+- Resource lifecycle and cleanup
+- Experience acceptance criteria
+- Evaluation level and target browser/device
+
+スクリーンショットだけでは完了せず、実際に入力へ反応し、同期し、劣化時に演奏を継続できることを証拠にする。
 
 ## Non-negotiable quality
 
@@ -26,8 +46,20 @@
 - frame drop、memory leak、audio glitch、long taskを計測する
 - autoplay、permission、device absenceのfallbackを持つ
 - browser固有APIはcapability detectionを行う
+- source、transform、target parameter の関係を追跡可能にする
+- authoring、armed、live、degraded state を混同しない
 - test削除、skip、閾値緩和でgreenにしない
 - live中に破壊的state migrationやunbounded resource creationを行わない
+
+## Layered evaluation
+
+1. static/contract: module API、parameter semantics、lifecycle、fallback
+2. deterministic tests: mapping、range、event order、state transition、cleanup
+3. instrumentation: frame time、dropped frames、long task、A/V drift、input latency、memory
+4. DOM/control review: mapping、状態、主要操作、live safety、keyboard/touch
+5. screenshot: authoring UI や視覚階層が変わる範囲だけ
+6. short capture/replay: 同期、transition、degraded recovery
+7. human rehearsal: 実ブラウザ、実音源、実入力、低性能条件
 
 ## Human decision boundary
 
@@ -37,7 +69,8 @@
 - 新しい有料サービスやライセンス制約のある素材/依存
 - deployment方式の変更
 - performance budgetを意図的に悪化させる判断
+- 主要 performance journey / state / live safety contract の意味変更
 
 ## Completion evidence
 
-build/testに加えて、代表sceneの実ブラウザ再生、入力sourceの配線、parameter変化、同期、frame time、console error、resource cleanupを確認する。visual変更は比較可能なscreenshotまたは短いcaptureを残す。
+build/testに加えて、代表sceneの実ブラウザ再生、入力sourceの配線、parameter変化、同期、frame time、console error、resource cleanupを確認する。visual変更は比較可能なscreenshotまたは短いcaptureを、性能・同期変更は計測値を残す。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — web-vj
+
+ブラウザ上で映像、音声、タイポグラフィ、3D、映像素材、インタラクションをリアルタイムに組み合わせるVJ実行・制作基盤。
+
+## Current direction
+
+- Remotion sequenceを再利用可能なobject/moduleとして読み込む
+- moduleの公開parameterをリアルタイム入力へ配線する
+- audio analysis、Web Speech API、MIDI/keyboard/touch等を入力sourceとして扱う
+- live performanceと編集/sequence authoringを同一モデルで接続する
+- visual素材、typography、layer、effect、scene、transitionを一貫したgraphとして扱う
+
+## Autonomous development loop
+
+1. 編集前に現行実装、README、関連Issue、既存のvisual/audio処理を調査する。
+2. 変更範囲、非変更範囲、受入条件、性能予算、検証方法を明示する。
+3. 一度に一つの演奏可能・デモ可能なvertical sliceを完成させる。
+4. Opus 5はarchitecture、module contract、interaction graph、難しい同期/性能障害へ使う。
+5. 通常実装はSonnet、探索は読み取り専用の安価なagentへ委任する。
+6. サブエージェントは独立した大規模作業だけに使い、同じscene/moduleを並行編集させない。
+7. 同じ失敗が3回続いたらパッチを止め、timing、frame、audio clock、render loop、browser API、GPU/CPUを分けて根本原因分析する。
+
+## Non-negotiable quality
+
+- audioとvisualの同期を主観だけで完了判定しない
+- frame drop、memory leak、audio glitch、long taskを計測する
+- autoplay、permission、device absenceのfallbackを持つ
+- browser固有APIはcapability detectionを行う
+- test削除、skip、閾値緩和でgreenにしない
+- live中に破壊的state migrationやunbounded resource creationを行わない
+
+## Human decision boundary
+
+- module/plugin public contractの破壊的変更
+- project/save formatの非互換変更
+- microphone/camera/recordingデータの保存・外部送信
+- 新しい有料サービスやライセンス制約のある素材/依存
+- deployment方式の変更
+- performance budgetを意図的に悪化させる判断
+
+## Completion evidence
+
+build/testに加えて、代表sceneの実ブラウザ再生、入力sourceの配線、parameter変化、同期、frame time、console error、resource cleanupを確認する。visual変更は比較可能なscreenshotまたは短いcaptureを残す。

--- a/docs/experience/README.md
+++ b/docs/experience/README.md
@@ -1,0 +1,136 @@
+# web-vj Experience Engineering
+
+この文書は、web-vj を単なる描画機能の集合ではなく、制作、配線、リハーサル、演奏、復帰まで連続した VJ 体験として設計、実装、評価するための正本である。`CLAUDE.md`、module contract、performance budget と併用する。
+
+## Experience principles
+
+1. **演奏の流れを止めない** — ライブ中の主要操作は短く、予測可能で、取り消し可能にする。
+2. **入力と映像の関係が分かる** — 何がどの parameter を動かしているか、信号の有無と強度を確認できる。
+3. **制作とライブを同じモデルでつなぐ** — sequence、scene、module、parameter、source の意味を環境ごとに変えない。
+4. **音楽的な反応を優先する** — 見た目だけでなく、同期、遅延、リズム、変化の連続性を評価する。
+5. **劣化しても演奏を続けられる** — 権限拒否、デバイス不在、低性能、接続断で安全な fallback へ移る。
+6. **ライブ中に壊れにくい** — 無制限な resource 作成、破壊的 state 変更、予測不能な自動切替を避ける。
+
+## Primary actors
+
+- VJ performer: scene を選び、入力を配線し、ライブ中に parameter と transition を操作する。
+- Visual author: Remotion sequence や module を制作し、公開 parameter と制約を定義する。
+- Remote participant/audience: スマホやブラウザから限定された interaction を送る。
+
+## Core journeys
+
+### J-VJ-01 Sequence/module を読み込む
+
+`moduleを選ぶ -> contractを確認 -> asset/依存を解決 -> preview -> sceneへ配置`
+
+成功条件:
+- 公開 parameter、入力型、既定値、resource 要件、fallback が分かる。
+- 読み込み失敗が他の scene やライブ状態を壊さない。
+
+### J-VJ-02 入力を parameter へ配線する
+
+`sourceを選ぶ -> signalを確認 -> parameterへmap -> range/curveを調整 -> preview -> 保存`
+
+成功条件:
+- source と target の関係、現在値、変換、clamp、遅延が見える。
+- audio analysis、speech、MIDI、keyboard、touch を同じ配線概念で扱う。
+
+### J-VJ-03 リハーサルからライブへ移る
+
+`scene確認 -> performance budget確認 -> input/fallback確認 -> arm -> live`
+
+成功条件:
+- 不足権限、asset、device、性能リスクを live 前に検出する。
+- authoring state と live state を明確に分離する。
+
+### J-VJ-04 ライブ演奏と scene transition
+
+`scene選択 -> parameter操作/自動反応 -> transition -> 次scene -> 継続`
+
+成功条件:
+- 操作結果と現在 scene が即座に分かる。
+- transition 中も frame、audio、resource が破綻しない。
+- 危険な編集は preview または queued change として扱う。
+
+### J-VJ-05 障害・性能劣化から復帰
+
+`frame drop/audio glitch/input loss/disconnect -> degraded表示 -> fallback/停止/再接続 -> 演奏継続`
+
+成功条件:
+- 無反応のまま放置せず、失われた機能と利用可能な代替を示す。
+- scene 全体を再読み込みせず復帰できる範囲を最大化する。
+
+### J-VJ-06 モバイル interaction
+
+`session参加 -> 許可されたcontrol表示 -> 操作 -> visual反応 -> session終了`
+
+成功条件:
+- audience が performer の制御権を奪わない。
+- 接続断、連打、不正値、複数端末を安全に扱う。
+
+## Performance state model
+
+`authoring -> previewing -> rehearsing -> armed -> live -> ended`
+
+例外状態:
+
+`degraded | input_missing | permission_denied | reconnecting | fallback_active | safe_stop`
+
+各状態は次を定義する。
+- allowed edits and controls
+- active scene/module/source
+- resource ownership and cleanup
+- performance budget
+- fallback behavior
+- visible status
+- transition guard
+
+## UX pattern contracts
+
+- **Module contract**: 入出力、parameter、asset、lifecycle、cleanup、fallback を明記する。
+- **Mapping inspector**: source、raw value、transform、target value、latency を一列で追える。
+- **Signal status**: connected、silent、clipped、stale、permission denied を区別する。
+- **Safe live edit**: 即時適用、次 beat/scene で適用、preview only を明示する。
+- **Scene transition**: 現在、次、duration、trigger、cancel/fallback を表示する。
+- **Degraded mode**: frame/audio/input のどれが劣化したかと継続方法を示す。
+- **Remote control boundary**: audience が変更可能な範囲、rate limit、session owner を明示する。
+
+## Issue / implementation contract
+
+ユーザー向け変更は以下を必須記載する。
+
+- Actor / performance outcome
+- Related journey ID and step
+- Entry, exit and degraded states
+- Target module/sequence/source/parameter
+- Interaction and timing contract
+- Performance budget and fallback
+- Resource lifecycle and cleanup
+- Experience acceptance criteria
+- Evaluation level and target browser/device
+
+## Evaluation ladder
+
+1. **Static/contract**: module API、parameter semantics、token、用語、lifecycle、fallback。
+2. **Deterministic tests**: mapping、range、event order、state transition、resource cleanup。
+3. **Instrumentation**: frame time、dropped frames、long task、audio/visual drift、input latency、memory。
+4. **DOM/control review**: mapping、状態、主要操作、live safety、keyboard/touch accessibility。
+5. **Screenshot**: authoring UI や視覚階層が変わる範囲だけ。
+6. **Short capture/replay**: J-VJ-02〜05 の同期、transition、劣化復帰を評価する。
+7. **Human rehearsal**: 実ブラウザ、実音源、実入力、低性能条件でライブ前確認する。
+
+## Outcome metrics
+
+- module 読み込み成功率と失敗からの復帰率
+- source-to-visual 入力遅延
+- audio/visual drift
+- dropped frames、long task、audio glitch
+- mapping のやり直し回数
+- live 中の誤操作と safe recovery
+- device/permission 不在時の継続率
+- remote interaction の拒否・rate limit・disconnect 件数
+- session 終了後の resource cleanup
+
+## Loop rule
+
+各周回は `Performance journey -> State/timing contract -> Module and mapping contract -> Playable vertical slice -> Instrumented evaluation -> Rehearsal outcome` の順で進める。スクリーンショットだけでは完了せず、実際に入力へ反応し、同期し、劣化時に演奏を継続できることを証拠にする。


### PR DESCRIPTION
## What changed

- Added a project-specific CLAUDE.md for the current web-vj direction
- Defined Remotion sequence/module loading and real-time interaction wiring as the central architecture goal
- Added model routing, performance/synchronization guardrails, human-decision boundaries, and completion evidence
- Added `docs/experience/README.md` as the VJ Experience Engineering model
- Extended the persistent loop state with performance journey, live/degraded states, timing contract, performance budget, resource lifecycle and layered evaluation

## Experience scope

- Core journeys: load module, map input, rehearse-to-live, perform/transition, recover from degradation, mobile interaction
- Explicit authoring / preview / rehearsal / armed / live / degraded / safe-stop states
- Cost-aware evaluation ladder: static/contract -> deterministic tests -> instrumentation -> DOM/control -> selective screenshot -> short capture -> human rehearsal
- Musical response, source-to-parameter traceability, safe live editing, fallback and cleanup are first-class acceptance criteria

## Why

Live visual tooling needs different completion criteria from ordinary CRUD development: frame time, audio/visual synchronization, browser permissions, device fallback, resource cleanup, performance flow and visual evidence must be treated as first-class acceptance criteria.

## Validation

Documentation/configuration-only change. No runtime code is modified. The repository currently appears to be documentation-first, so a project-specific executable quality gate should be added once the active implementation layout and package scripts are confirmed.

## Follow-up

Use J-VJ-01 and J-VJ-02 to implement the first playable module-loading and interaction-wiring slice, then apply J-VJ-05 to prove degraded-mode recovery.